### PR TITLE
Correct income_classifier.py

### DIFF
--- a/Chapter 02/code/income_classifier.py
+++ b/Chapter 02/code/income_classifier.py
@@ -75,10 +75,10 @@ for i, item in enumerate(input_data):
     if item.isdigit():
         input_data_encoded[i] = int(input_data[i])
     else:
-        input_data_encoded[i] = int(label_encoder[count].transform(input_data[i]))
+        input_data_encoded[i] = int(label_encoder[count].transform([input_data[i]]))
         count += 1 
 
-input_data_encoded = np.array(input_data_encoded)
+input_data_encoded = np.array([input_data_encoded])
 
 # Run classifier on encoded datapoint and print output
 predicted_class = classifier.predict(input_data_encoded)


### PR DESCRIPTION
Fix issue about using LabelEncoder.transform and np.array functions, as they accept only arrays.